### PR TITLE
Implement MCP tool support (list + dispatch) via fastmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,15 +291,33 @@ model = "gpt-4o"
 
 # MCP servers allowed in this channel
 [[mcp_server]]
-name = "github"
-url = "mcp://localhost:3001"
-allowed_tools = ["list_prs", "get_file", "create_comment", "trigger_workflow"]
+name = "github"                                # namespace prefix: tools appear as github__<tool>
+url = "https://api.githubcopilot.com/mcp/"     # HTTP(S) MCP endpoint (Streamable HTTP)
+auth_env = "GITHUB_MCP_TOKEN"                  # NAME of an env var holding a bearer token
+allowed_tools = ["list_pull_requests", "get_file_contents", "add_issue_comment"]
 
+# Long-running tools? Mark the server task_mode and calls run as MCP
+# background tasks (polled to completion instead of blocking the request).
 [[mcp_server]]
-name = "linear"
-url = "mcp://localhost:3002"
-allowed_tools = ["list_issues", "create_issue", "update_status"]
+name = "crawler"
+url = "http://localhost:3001/mcp"
+auth_env = "CRAWLER_MCP_TOKEN"
+task_mode = true
+timeout = 1200                                 # max seconds per tool call (default 1200)
 ```
+
+Field reference:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Namespace prefix — the server's tools are exposed to the model as `<name>__<tool>` |
+| `url` | yes | HTTP(S) URL of the MCP endpoint (Streamable HTTP) |
+| `auth_env` | no | Name of an environment variable holding a bearer token. Resolved at connect time — the secret itself never sits in `tools.toml` |
+| `allowed_tools` | no | Allowlist of tool names (un-namespaced). Omit to expose every tool. Enforced at listing *and* dispatch |
+| `task_mode` | no | Run this server's tools as MCP background tasks — for tools that run minutes, not seconds |
+| `timeout` | no | Max seconds a single tool call may run (foreground call or background-task wait). Default 1200 |
+
+Tool listings are cached per channel for 60 seconds, so config edits and server-side tool changes show up within a minute. An unreachable or misconfigured server never breaks the agent — its tools are skipped for the turn, and a failed tool call returns a plain error message to the model instead of crashing the loop.
 
 ### Skills — auto-created institutional knowledge
 

--- a/channels/example/tools.toml
+++ b/channels/example/tools.toml
@@ -8,14 +8,30 @@
 # model = "gemini/gemini-2.0-flash"         # use Gemini
 # model = "groq/llama-3.3-70b-versatile"   # use Groq
 
-# Example: GitHub MCP server
-# [[mcp_server]]
-# name = "github"
-# url = "mcp://localhost:3001"
-# allowed_tools = ["list_prs", "get_file", "create_comment"]
+# MCP servers — each entry exposes the server's tools to this channel's agent,
+# namespaced as "<name>__<tool>" (e.g. github__list_pull_requests).
+#
+#   name           required. Namespace prefix for the server's tools.
+#   url            required. HTTP(S) URL of the MCP endpoint (Streamable HTTP).
+#   auth_env       optional. NAME of an environment variable holding a bearer
+#                  token. The token is read from the environment at connect
+#                  time — never put the secret itself in this file.
+#   allowed_tools  optional. Allowlist of tool names; omit to expose all tools.
+#   task_mode      optional. Run this server's tools as MCP background tasks
+#                  (for long-running tools); the agent polls for the result.
+#   timeout        optional. Max seconds a single tool call may run
+#                  (foreground call or background-task wait). Default 1200.
 
-# Example: Linear MCP server
+[[mcp_server]]
+name = "github"
+url = "https://api.githubcopilot.com/mcp/"
+auth_env = "GITHUB_MCP_TOKEN"
+allowed_tools = ["list_pull_requests", "get_file_contents", "add_issue_comment"]
+
+# Example: a self-hosted server whose tools run long (crawls, batch jobs)
 # [[mcp_server]]
-# name = "linear"
-# url = "mcp://localhost:3002"
-# allowed_tools = ["list_issues", "create_issue", "update_status"]
+# name = "crawler"
+# url = "http://localhost:3001/mcp"
+# auth_env = "CRAWLER_MCP_TOKEN"
+# task_mode = true
+# timeout = 1200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "slack-bolt>=1.21.0",
     "litellm>=1.45.0",
     "mem0ai>=0.1.0",
-    "mcp>=1.0.0",
+    "fastmcp>=3.0",
     "aiosqlite>=0.20.0",
     "apscheduler>=3.10.0",
     "pydantic>=2.7.0",
@@ -25,6 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "fastmcp[tasks]>=3.0",  # task-capable in-process MCP server for tests
     "pytest>=8.2.0",
     "pytest-asyncio>=0.23.0",
     "pytest-mock>=3.14.0",

--- a/tagopen/agent/loop.py
+++ b/tagopen/agent/loop.py
@@ -12,7 +12,7 @@ from tagopen.config import settings
 from tagopen.llm import acompletion
 from tagopen.memory.store import MessageStore
 from tagopen.memory.writer import run_memory_curation
-from tagopen.tools.registry import get_channel_tools, dispatch_tool
+from tagopen.tools.registry import dispatch_tool, get_channel_tools
 
 if TYPE_CHECKING:
     from slack_bolt.async_app import AsyncApp
@@ -56,7 +56,7 @@ async def run_agent_loop(
 
     system_prompt = build_system_prompt(channel_id, user_map)
     messages = await build_messages(channel_id, user_id, display_name, text, thread_ts, store)
-    tools = get_channel_tools(channel_id)
+    tools = await get_channel_tools(channel_id)
 
     tool_call_count = 0
     final_text = ""

--- a/tagopen/gateway/router.py
+++ b/tagopen/gateway/router.py
@@ -1,5 +1,6 @@
 """Channel router — maps (workspace_id, channel_id) to an AgentSession and runs the loop."""
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -24,10 +25,7 @@ class AgentSession:
     channel_id: str
     # Shared lock so concurrent @mentions in the same channel are serialized
     # preventing context corruption from parallel writes.
-    _lock: asyncio.Lock = field(default_factory=lambda: __import__("asyncio").Lock())
-
-
-import asyncio  # noqa: E402 — needed for Lock reference above
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 def get_or_create_session(workspace_id: str, channel_id: str) -> AgentSession:

--- a/tagopen/memory/store.py
+++ b/tagopen/memory/store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
 from pathlib import Path
 
 import aiosqlite
@@ -88,7 +87,7 @@ class MessageStore:
             """SELECT ts, role, user_id, display_name, content
                FROM messages
                WHERE channel_id = ?
-               ORDER BY created_at DESC
+               ORDER BY created_at DESC, rowid DESC
                LIMIT ?""",
             (self._channel_id, limit),
         ) as cursor:

--- a/tagopen/tools/registry.py
+++ b/tagopen/tools/registry.py
@@ -1,42 +1,188 @@
-"""Tool registry — loads allowed tools per channel from TOOLS.md / tools.toml.
+"""Tool registry — loads allowed tools per channel from tools.toml.
 
-All tools are exposed as MCP-compatible function schemas so the agent can call them.
-Built-in tools are always available. Channel admins can add MCP servers via TOOLS.md.
+Built-in tools are always available. Channel admins can add MCP servers via
+``[[mcp_server]]`` entries in tools.toml. Each server's tools are listed over
+the MCP protocol, converted to LiteLLM function schemas, and exposed to the
+model namespaced as ``<server>__<tool>``.
+
+Server entry schema (tools.toml)::
+
+    [[mcp_server]]
+    name = "github"                      # required — namespace prefix
+    url = "https://example.com/mcp"      # required — HTTP(S) MCP endpoint
+    auth_env = "GITHUB_MCP_TOKEN"        # optional — NAME of an env var holding
+                                         #   a bearer token (resolved at connect
+                                         #   time; no secret sits in tools.toml)
+    allowed_tools = ["list_prs"]         # optional — allowlist; omit = all tools
+    task_mode = false                    # optional — run tools as MCP background
+                                         #   tasks (SEP-1686) and poll for the
+                                         #   result instead of blocking the call
+    timeout = 1200                       # optional — max seconds a single tool
+                                         #   call may run (foreground call or
+                                         #   background-task wait)
+
+MCP failures never crash the agent loop: listing failures drop that server's
+tools for the turn, and dispatch failures return a plain error string as the
+tool result so the model can tell the user what went wrong.
 """
 
 from __future__ import annotations
 
+import json
 import logging
-from pathlib import Path
+import os
+import time
+from dataclasses import dataclass
 from typing import Any
 
+import httpx
 import toml
+from fastmcp import Client
 
 from tagopen.config import settings
 from tagopen.tools.builtins import BUILTIN_TOOLS, dispatch_builtin
 
 logger = logging.getLogger(__name__)
 
-# Cache parsed tool configs per channel
-_tool_configs: dict[str, list[dict]] = {}
+# How long listed MCP tool schemas are reused before re-listing (seconds).
+# A busy channel re-lists at most once per TTL; edits to tools.toml or
+# server-side tool changes are picked up within this window.
+MCP_TOOLS_TTL_SECONDS = 60.0
+
+# Default cap on a single MCP tool call — a foreground call or a
+# background-task wait. Override per server with `timeout` in tools.toml.
+DEFAULT_TOOL_TIMEOUT_SECONDS = 1200.0
+
+# Connect + list timeout while building a channel's schema — kept short so an
+# unreachable server cannot stall message handling.
+LIST_TOOLS_TIMEOUT_SECONDS = 15.0
 
 
-def get_channel_tools(channel_id: str) -> list[dict]:
-    """Return LiteLLM-compatible tool schemas for this channel."""
+@dataclass
+class _ChannelTools:
+    """Cached MCP tool schemas for one channel."""
+
+    mcp_tools: list[dict]
+    expires_at: float  # time.monotonic() deadline
+
+
+# Cache of listed MCP tool schemas per channel
+_tool_configs: dict[str, _ChannelTools] = {}
+
+
+def _load_server_configs(channel_id: str) -> dict[str, dict]:
+    """Parse ``[[mcp_server]]`` entries from the channel's tools.toml.
+
+    Returns ``{server_name: entry}``. Invalid entries (missing name/url,
+    non-HTTP url) are skipped with a warning. Never raises.
+    """
+    path = settings.channels_dir / channel_id / "tools.toml"
+    if not path.exists():
+        return {}
+    try:
+        config = toml.loads(path.read_text())
+    except Exception:
+        logger.exception("Failed to parse tools.toml for channel=%s", channel_id)
+        return {}
+
+    servers: dict[str, dict] = {}
+    for entry in config.get("mcp_server", []):
+        name, url = entry.get("name"), entry.get("url")
+        if not name or not url:
+            logger.warning(
+                "Skipping [[mcp_server]] entry without name/url in channel=%s", channel_id
+            )
+            continue
+        if not str(url).startswith(("http://", "https://")):
+            logger.warning(
+                "Skipping MCP server '%s' in channel=%s: only HTTP(S) URLs are supported, got %r",
+                name,
+                channel_id,
+                url,
+            )
+            continue
+        servers[str(name)] = entry
+    return servers
+
+
+def _resolve_auth(server: dict) -> tuple[str | None, str | None]:
+    """Resolve the bearer token for a server entry.
+
+    ``auth_env`` names an environment variable holding the token. Returns
+    ``(token, error_message)`` — exactly one is set when auth is configured.
+    """
+    auth_env = server.get("auth_env")
+    if not auth_env:
+        return None, None
+    token = os.environ.get(auth_env)
+    if not token:
+        return None, (
+            f"MCP server '{server['name']}' requires a bearer token in environment "
+            f"variable '{auth_env}', which is not set."
+        )
+    return token, None
+
+
+async def _list_server_tools(name: str, server: dict) -> list[dict]:
+    """Connect to one MCP server and return its tools as LiteLLM schemas."""
+    token, auth_err = _resolve_auth(server)
+    if auth_err:
+        logger.warning("%s Skipping tool listing.", auth_err)
+        return []
+
+    allowed = server.get("allowed_tools")
+    schemas: list[dict] = []
+    async with Client(
+        server["url"],
+        auth=token,
+        timeout=LIST_TOOLS_TIMEOUT_SECONDS,
+        init_timeout=LIST_TOOLS_TIMEOUT_SECONDS,
+    ) as client:
+        for tool in await client.list_tools():
+            if allowed is not None and tool.name not in allowed:
+                continue
+            schemas.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"{name}__{tool.name}",
+                        "description": tool.description or "",
+                        "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+                    },
+                }
+            )
+    return schemas
+
+
+async def get_channel_tools(channel_id: str) -> list[dict]:
+    """Return LiteLLM-compatible tool schemas for this channel.
+
+    Built-ins are always included. MCP tools are listed live from each
+    configured server and cached for MCP_TOOLS_TTL_SECONDS. A server that is
+    unreachable or misconfigured contributes no tools for the turn — the agent
+    keeps working with whatever else is available.
+    """
     tools = list(BUILTIN_TOOLS)  # always include built-ins
 
-    tools_toml_path = settings.channels_dir / channel_id / "tools.toml"
-    if tools_toml_path.exists():
-        try:
-            config = toml.loads(tools_toml_path.read_text())
-            for server in config.get("mcp_server", []):
-                # For now, MCP servers are registered but called via HTTP
-                # Full MCP client implementation in Phase 2
-                logger.debug("MCP server registered: %s for channel=%s", server.get("name"), channel_id)
-        except Exception:
-            logger.exception("Failed to parse tools.toml for channel=%s", channel_id)
+    cached = _tool_configs.get(channel_id)
+    if cached is not None and time.monotonic() < cached.expires_at:
+        return tools + cached.mcp_tools
 
-    return tools
+    mcp_tools: list[dict] = []
+    for name, server in _load_server_configs(channel_id).items():
+        try:
+            listed = await _list_server_tools(name, server)
+            mcp_tools.extend(listed)
+            logger.debug(
+                "MCP server '%s': %d tools listed for channel=%s", name, len(listed), channel_id
+            )
+        except Exception as e:
+            logger.warning("MCP server '%s' unavailable for channel=%s: %s", name, channel_id, e)
+
+    _tool_configs[channel_id] = _ChannelTools(
+        mcp_tools=mcp_tools, expires_at=time.monotonic() + MCP_TOOLS_TTL_SECONDS
+    )
+    return tools + mcp_tools
 
 
 async def dispatch_tool(fn_name: str, args: dict[str, Any], channel_id: str) -> Any:
@@ -48,5 +194,66 @@ async def dispatch_tool(fn_name: str, args: dict[str, Any], channel_id: str) -> 
     if fn_name in ("memory_append", "memory_replace"):
         return None
 
+    for name, server in _load_server_configs(channel_id).items():
+        prefix = f"{name}__"
+        if fn_name.startswith(prefix):
+            return await _dispatch_mcp(name, server, fn_name[len(prefix) :], fn_name, args)
+
     logger.warning("Unknown tool: %s in channel=%s", fn_name, channel_id)
     return f"Tool '{fn_name}' not found."
+
+
+async def _dispatch_mcp(
+    server_name: str, server: dict, tool_name: str, fn_name: str, args: dict[str, Any]
+) -> str:
+    """Call one MCP tool. On any failure, return an honest error string.
+
+    The allowed_tools allowlist is enforced here as well as at listing time,
+    so a call to a filtered tool fails even if the model hallucinates it.
+    In task_mode the call is submitted as an MCP background task and polled
+    to completion, keeping long-running work off the request path.
+    """
+    allowed = server.get("allowed_tools")
+    if allowed is not None and tool_name not in allowed:
+        msg = f"Tool '{fn_name}' is not in this channel's allowed_tools for '{server_name}'."
+        logger.warning("%s", msg)
+        return msg
+
+    token, auth_err = _resolve_auth(server)
+    if auth_err:
+        logger.warning("%s", auth_err)
+        return auth_err
+
+    timeout = float(server.get("timeout", DEFAULT_TOOL_TIMEOUT_SECONDS))
+    try:
+        async with Client(server["url"], auth=token) as client:
+            if server.get("task_mode"):
+                task = await client.call_tool(tool_name, args, task=True)
+                await task.wait(timeout=timeout)
+                result = await task.result()
+            else:
+                result = await client.call_tool(tool_name, args, timeout=timeout)
+        return _render_result(result)
+    except TimeoutError:
+        msg = f"MCP tool '{fn_name}' timed out after {timeout:.0f}s."
+    except httpx.HTTPStatusError as e:
+        code = e.response.status_code
+        if code in (401, 403):
+            msg = (
+                f"MCP server '{server_name}' rejected the call as unauthorized (HTTP {code}). "
+                f"Check the token in the '{server.get('auth_env', '<unset>')}' env var."
+            )
+        else:
+            msg = f"MCP server '{server_name}' returned HTTP {code} for '{fn_name}'."
+    except Exception as e:
+        msg = f"MCP tool '{fn_name}' failed: {e}"
+    logger.warning("%s", msg)
+    return msg
+
+
+def _render_result(result: Any) -> str:
+    """Render a CallToolResult for the model: structured content, else text."""
+    if result.structured_content is not None:
+        return json.dumps(result.structured_content, default=str)
+    texts = [block.text for block in result.content if hasattr(block, "text")]
+    return "\n".join(texts) if texts else "(empty result)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test configuration.
+
+tagopen.config instantiates Settings at import time, which requires the two
+Slack tokens. Provide dummies so unit tests run without a real environment.
+"""
+
+import os
+
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test")
+os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test")

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,0 +1,174 @@
+"""Tests for MCP tool listing and dispatch against a real in-process server."""
+
+import asyncio
+import json
+import socket
+import time
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.server.auth.providers.debug import DebugTokenVerifier
+
+from tagopen.config import settings
+from tagopen.tools import registry
+from tagopen.tools.builtins import BUILTIN_TOOLS
+from tagopen.tools.registry import dispatch_tool, get_channel_tools
+
+TEST_TOKEN = "test-bearer-token"
+CHANNEL = "C_MCP"
+
+BUILTIN_NAMES = {t["function"]["name"] for t in BUILTIN_TOOLS}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def mcp_server_url():
+    """Run a bearer-token-protected FastMCP server in-process; yield its URL."""
+    server = FastMCP("testsrv", auth=DebugTokenVerifier(validate=lambda t: t == TEST_TOKEN))
+
+    @server.tool(task=True)
+    async def echo(text: str) -> dict:
+        """Echo the input back."""
+        return {"echoed": text}
+
+    @server.tool
+    async def add(a: int, b: int) -> dict:
+        """Add two integers."""
+        return {"sum": a + b}
+
+    port = _free_port()
+    run = asyncio.create_task(server.run_http_async(host="127.0.0.1", port=port, show_banner=False))
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    deadline = time.monotonic() + 15
+    while True:
+        try:
+            async with Client(url, auth=TEST_TOKEN) as client:
+                await client.list_tools()
+            break
+        except Exception:
+            if time.monotonic() > deadline:
+                run.cancel()
+                raise
+            await asyncio.sleep(0.05)
+
+    yield url
+
+    run.cancel()
+    try:
+        await run
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.fixture
+def write_tools_toml(tmp_path, monkeypatch):
+    """Point the channel dir at tmp_path and return a tools.toml writer."""
+    monkeypatch.setattr(settings, "data_dir", tmp_path)
+    monkeypatch.setenv("MCP_TEST_TOKEN", TEST_TOKEN)
+    registry._tool_configs.clear()
+
+    def write(text: str) -> None:
+        path = tmp_path / "channels" / CHANNEL / "tools.toml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        registry._tool_configs.clear()
+
+    return write
+
+
+def _server_entry(url: str, extra: str = "") -> str:
+    return f'''
+[[mcp_server]]
+name = "testsrv"
+url = "{url}"
+auth_env = "MCP_TEST_TOKEN"
+{extra}
+'''
+
+
+async def test_mcp_tools_listed_namespaced_and_schema_shaped(mcp_server_url, write_tools_toml):
+    write_tools_toml(_server_entry(mcp_server_url))
+
+    tools = await get_channel_tools(CHANNEL)
+    names = {t["function"]["name"] for t in tools}
+
+    assert BUILTIN_NAMES <= names  # built-ins always present
+    assert {"testsrv__echo", "testsrv__add"} <= names
+
+    echo = next(t for t in tools if t["function"]["name"] == "testsrv__echo")
+    assert echo["type"] == "function"
+    assert echo["function"]["description"]
+    params = echo["function"]["parameters"]
+    assert params["type"] == "object"
+    assert "text" in params["properties"]
+
+
+async def test_authorized_dispatch_returns_tool_result(mcp_server_url, write_tools_toml):
+    write_tools_toml(_server_entry(mcp_server_url))
+
+    result = await dispatch_tool("testsrv__echo", {"text": "hello"}, channel_id=CHANNEL)
+    assert json.loads(result) == {"echoed": "hello"}
+
+
+async def test_wrong_token_yields_error_string(mcp_server_url, write_tools_toml, monkeypatch):
+    write_tools_toml(_server_entry(mcp_server_url))
+    monkeypatch.setenv("MCP_TEST_TOKEN", "wrong-token")
+
+    # Listing degrades to built-ins only — no exception escapes
+    tools = await get_channel_tools(CHANNEL)
+    assert {t["function"]["name"] for t in tools} == BUILTIN_NAMES
+
+    # Dispatch returns an honest error string, not an exception
+    result = await dispatch_tool("testsrv__echo", {"text": "hi"}, channel_id=CHANNEL)
+    assert isinstance(result, str)
+    assert "unauthorized" in result.lower()
+
+
+async def test_missing_auth_env_yields_error_string(mcp_server_url, write_tools_toml, monkeypatch):
+    write_tools_toml(_server_entry(mcp_server_url))
+    monkeypatch.delenv("MCP_TEST_TOKEN")
+
+    tools = await get_channel_tools(CHANNEL)
+    assert {t["function"]["name"] for t in tools} == BUILTIN_NAMES
+
+    result = await dispatch_tool("testsrv__echo", {"text": "hi"}, channel_id=CHANNEL)
+    assert isinstance(result, str)
+    assert "MCP_TEST_TOKEN" in result and "not set" in result
+
+
+async def test_allowed_tools_filters_listing_and_dispatch(mcp_server_url, write_tools_toml):
+    write_tools_toml(_server_entry(mcp_server_url, 'allowed_tools = ["echo"]'))
+
+    tools = await get_channel_tools(CHANNEL)
+    names = {t["function"]["name"] for t in tools}
+    assert "testsrv__echo" in names
+    assert "testsrv__add" not in names
+
+    # Dispatch enforces the allowlist too, even if the model hallucinates the call
+    result = await dispatch_tool("testsrv__add", {"a": 1, "b": 2}, channel_id=CHANNEL)
+    assert isinstance(result, str)
+    assert "allowed_tools" in result
+
+    # The allowed tool still works
+    result = await dispatch_tool("testsrv__echo", {"text": "ok"}, channel_id=CHANNEL)
+    assert json.loads(result) == {"echoed": "ok"}
+
+
+async def test_task_mode_dispatch_completes(mcp_server_url, write_tools_toml):
+    write_tools_toml(_server_entry(mcp_server_url, "task_mode = true\ntimeout = 30"))
+
+    result = await dispatch_tool("testsrv__echo", {"text": "background"}, channel_id=CHANNEL)
+    assert json.loads(result) == {"echoed": "background"}
+
+
+async def test_unknown_tool_still_reports_not_found(write_tools_toml):
+    write_tools_toml("")  # no MCP servers configured
+
+    result = await dispatch_tool("nosuch__tool", {}, channel_id=CHANNEL)
+    assert result == "Tool 'nosuch__tool' not found."


### PR DESCRIPTION

The README advertises MCP-native tools, but the `[[mcp_server]]` entries in `tools.toml` were parsed and discarded (`registry.py` logged the server name at DEBUG and dropped the dict — "Full MCP client implementation in Phase 2"), and the `mcp>=1.0.0` dependency was never imported. Any MCP tool call fell through to `"Tool not found"`.

This PR completes the feature end to end: MCP servers declared in a channel's `tools.toml` now have their tools listed over the MCP protocol, exposed to the model as LiteLLM function schemas, and dispatched with bearer auth — including long-running tools via MCP background tasks.

## What changed

- **`tagopen/tools/registry.py`** — real implementation. `get_channel_tools` is now async: it connects to each configured server, lists tools, converts MCP schemas to LiteLLM function schemas, namespaces them as `<server>__<tool>`, and caches per channel. `dispatch_tool` routes namespaced calls to the owning server.
- **`tagopen/agent/loop.py`** — awaits the now-async `get_channel_tools` (its only call site).
- **`pyproject.toml`** — replaces the dead `mcp>=1.0.0` dependency with `fastmcp>=3.0`, which subsumes the official SDK and adds the two things this feature needs: bearer auth (`Client(url, auth=<token>)`) and the background-task extension (SEP-1686). `fastmcp[tasks]` is added to dev extras for the task-capable in-process test server.
- **`channels/example/tools.toml` + README** — the `mcp://localhost:3001` placeholders are replaced with a working, documented example of the real schema.

## Config schema

```toml
[[mcp_server]]
name = "github"                              # required — tools exposed as <name>__<tool>
url = "https://api.githubcopilot.com/mcp/"   # required — HTTP(S) Streamable HTTP endpoint
auth_env = "GITHUB_MCP_TOKEN"                # optional — NAME of an env var holding a bearer token
allowed_tools = ["get_file_contents"]        # optional — allowlist; omit = all tools
task_mode = false                            # optional — run tools as MCP background tasks
timeout = 1200                               # optional — max seconds per call (default 1200)
```

Design decisions, and why:

- **`auth_env` names an env var; the token is resolved at connect time.** `tools.toml` lives on the same data volume the agent writes to — a literal token there would be one `memory_append` away from leaking. With `auth_env`, no secret ever sits in channel config.
- **60-second per-channel cache of listed tools.** A busy channel re-lists at most once per TTL; edits to `tools.toml` and server-side tool changes show up within a minute. Dispatch re-reads only the (local) config file, never re-lists.
- **`task_mode` for long-running tools.** The per-channel session lock is held for a whole turn, so a foreground ten-minute tool call would block every other @mention in the channel *and* typically outlive HTTP timeouts. Task-mode servers are called with `task=True` and polled to completion (`timeout` caps both foreground calls and task waits).
- **Failures are honest and non-fatal.** An unreachable or misconfigured server contributes no tools for the turn; connection, auth, and tool errors come back to the model as plain error strings (logged at warning). The Slack loop never crashes because a tool did.
- **`allowed_tools` is enforced at dispatch as well as listing**, so a hallucinated call to a filtered tool is rejected rather than proxied.
- **HTTP(S) transports only** — matching the advertised remote-server use case. Non-HTTP `url` values are skipped with a warning.

## Tests

Seven new tests in `tests/unit/test_mcp_tools.py`, all against a real in-process fastmcp server with a bearer-token verifier (no mocks of the MCP layer):

1. Tools listed, namespaced, and LiteLLM-schema-shaped (built-ins still present)
2. Authorized dispatch returns the tool's structured result
3. Wrong token → listing degrades to built-ins, dispatch returns an error string (no exception)
4. Missing `auth_env` variable → same honest degradation, error names the variable
5. `allowed_tools` filters listing *and* blocks dispatch of filtered tools
6. `task_mode` dispatch completes end to end
7. Unknown-tool fallthrough still reports "not found"

Full suite: **15 passed** (8 pre-existing + 7 new).

## Pre-existing fixes required to run the suite (first commit, kept separate)

The suite could not pass on a fresh clone at the declared Python floor, so the first commit contains three minimal fixes:

- `tagopen/gateway/router.py` imported `asyncio` *below* the dataclass that uses `asyncio.Lock` as a field annotation — on Python 3.11–3.13 the module (and therefore the app) fails at import with `NameError`. The import moved to the top.
- `MessageStore.get_recent_messages` ordered by `created_at` alone (second granularity), so messages inserted within the same second came back in arbitrary order — `test_message_ordering` failed, and context building depends on this order. Added a `rowid` tiebreaker.
- `tagopen.config` requires the two Slack tokens at import time, so tests could not even collect without a configured environment. Added a `tests/conftest.py` providing dummies.

## Out of scope (observed, not touched)

- `search_channel_history` returns its own arguments as the tool result — the store-aware dispatch it points to was never completed.
- The `run_python` sandbox passes an empty `__builtins__` dict when `__builtins__` is a module (the common case), so snippets lose all builtins.
- `ruff check` reports 24 pre-existing findings across otherwise-untouched files (including one each in `loop.py`/`store.py` that predate this patch); left as-is to keep the diff focused.
- No lockfile; roadmap checkboxes don't reflect what's implemented.

Happy to adjust schema field names or defaults if you'd prefer different conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsF9SPhooPVzGKGqSX5wnp
