### PR TITLE
Add dsh-launcher to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ For the complete, continuously-updated plugin index (well over a thousand entrie
 - [awesome-hermes-agent](https://github.com/Anil-matcha/awesome-hermes-agent) — curated resources for Hermes Agent (Nous Research), the self-evolving skill-generating agent.
 - [Open-Generative-AI](https://github.com/Anil-matcha/Open-Generative-AI) — a broader curated hub of open-source generative AI tools and platforms.
 - [Generative-Media-Skills](https://github.com/Anil-matcha/Generative-Media-Skills) — agent-skill building blocks for generative media workflows, in the same plugin/skill spirit as `dsh`.
+- [iceleaf916/dsh-launcher](https://github.com/iceleaf916/dsh-launcher) — macOS menu-bar launcher for dsh: start/stop/restart the web service, hot reload, auto-start at login, and open the UI in a system or built-in browser.
 
 ## Contributing
 


### PR DESCRIPTION
Adds [dsh-launcher](https://github.com/iceleaf916/dsh-launcher), a macOS menu-bar launcher for DeepSeek Harness (`dsh`), to the Related Projects section.

It is a desktop companion app rather than a Web UI plugin: it manages the `dsh --profile web` service (start/stop/restart, hot reload, auto-start at login) and opens the dsh UI in a system or built-in browser.