### PR TITLE
docs: add dsh-change-budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AngelosZou/graphlint](https://github.com/AngelosZou/graphlint/tree/main/integrations/dsh) — Dead-code detection for AI-generated codebases via dependency-graph reachability.
 - [aokamoaki/dsh-startup-guard](https://github.com/aokamoaki/dsh-startup-guard) — Repairs corrupt session logs and quarantines crash-causing bundles so a broken plugin can't brick startup.
 - [ayahunter/dsh-plugin-clinic](https://github.com/ayahunter/dsh-plugin-clinic) — Read-only health check of the installed plugin set: loader health, dependency integrity, and install-script risk.
+- [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) — Configurable per-turn budgets that limit distinct files, mutation calls, and UTF-8 payload bytes before supported file-mutation tools run.
 
 ### Plugin Markets & Managers
 


### PR DESCRIPTION
## Summary

Adds [`Raphaelutumn/dsh-change-budget`](https://github.com/Raphaelutumn/dsh-change-budget), a DeepSeek Harness plugin that applies configurable per-turn budgets before supported file-mutation tool bodies run.

The budgets independently limit distinct files, mutation calls, and UTF-8 payload bytes. The repository declares `dsh.bundle`, ships a public `v0.1.0` release, and documents unsupported Shell/PowerShell mutations explicitly.

## Verification

- Plugin verification: 5 test files, 20 tests passed
- TypeScript typecheck and build passed
- Added the official `dsh-plugin` repository topic
