### PR TITLE
Add maddogfinance/dsh-trading (Tools & Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [863683348/dsh-plugin-translation](https://github.com/863683348/dsh-plugin-translation) — Translation toolkit: segmentation, glossary extraction, source-target QA, and translation memory.
 - [863683348/dsh-plugin-finance-data](https://github.com/863683348/dsh-plugin-finance-data) — Finance toolkit: currency formatting, return/CAGR math, valuation ratios, and risk metrics.
 
+- [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) — Research-only trading workbench: typed market-data seam with BYO providers, multi-timeframe indicator snapshots, interactive chart cards with provenance-gated model annotations, and a pre-execute risk-guard that blocks execution-shaped tool calls.
 ### Vision & Multimodal
 
 - [54xkeee/dsh-vision](https://github.com/54xkeee/dsh-vision) — Zero-cost vision for text-only DeepSeek via a logged-in Chrome CDP bridge, with fallback providers.


### PR DESCRIPTION
Adds **dsh-trading** — research-only trading workbench plugins for DeepSeek Harness.

- Repo: https://github.com/maddogfinance/dsh-trading (MIT, topics: dsh, dsh-plugin)
- npm: `dsh plugin --profile trading add @dsh-trading/bundle`
- 80s demo: https://www.youtube.com/watch?v=9KLpy-jPtKY
- Hard boundary: no execution seam exists; risk-guard additionally refuses execution-shaped tool calls at tools/pre-execute.