### PR TITLE
Add opencues/opencues to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AKS1st/dsh-sysmon](https://github.com/AKS1st/dsh-sysmon) — Floating CPU/memory/disk widget with threshold color warnings.
 - [hanzhangzzz/dsh-diagram](https://github.com/hanzhangzzz/dsh-diagram) — Editable Excalidraw diagrams embedded directly in conversations.
 - [giiiiiithub/terminal](https://github.com/giiiiiithub/terminal) — A real PTY terminal panel via node-pty and xterm.js, with multi-tab sessions and a dock/floating window.
+- [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) — Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings flagged as you type. Uses the model dsh is already configured with, so no API key.
 - [Ricketts-Guo/dsh-shortcuts](https://github.com/Ricketts-Guo/dsh-shortcuts) — 34 pre-registered keyboard shortcuts (sessions, views, clipboard, models, silent permission cycling), one-click recording to bind your own.
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) — In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering.
 


### PR DESCRIPTION
One line under **UI Enhancements**, placed alphabetically.

OpenCues puts word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings are flagged as you type. It uses whichever model dsh is already configured with, so it needs no API key of its own.

Install: `dsh plugin --profile web add @opencues/dsh`

Against the stated bar:

- **One line**, matching the section's `[owner/repo](url) — description` shape.
- **The actual plugin repo**, not a fork or mirror. It is a monorepo, so the link points at the plugin's own directory.
- **Installs and does what the description says** — verified end to end against the published npm package on a clean machine: no `.cues` config, no API keys in the environment, `dsh plugin --profile web add @opencues/dsh`, then `the capital of iceland is _` fills to `Reykjavik` on DeepSeek's own model.
- The repo carries the `dsh-plugin` topic.