### PR TITLE
docs: add dsh-workflow-isolate

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) — Compares the harness and every plugin against npm/GitHub releases with one-click updates and rollback.
 - [aokamoaki/dsh-startup-guard](https://github.com/aokamoaki/dsh-startup-guard) — Repairs corrupt session logs and quarantines crash-causing bundles so a broken plugin can't brick startup.
 - [ayahunter/dsh-plugin-clinic](https://github.com/ayahunter/dsh-plugin-clinic) — Read-only health check of the installed plugin set: loader health, dependency integrity, install-script risk.
+- [Linxiushen/dsh-workflow-isolate](https://github.com/Linxiushen/dsh-workflow-isolate) — Runs model-written workflows in a fresh QuickJS/WASM runtime with bounded memory, execution fuel, wall time, and child-agent fan-out.
 
 ### Plugin Markets & Managers
 


### PR DESCRIPTION
## Summary

Adds [`Linxiushen/dsh-workflow-isolate`](https://github.com/Linxiushen/dsh-workflow-isolate) to **Development & Runtime**.

It is a DeepSeek Harness `WorkflowEngine` bundle that runs model-written orchestration scripts in per-run QuickJS/WASM runtimes with bounded guest and child-agent resources.

## Verification

- Actual plugin repository, not a fork or mirror
- Declares `dsh.bundle` and targets DSH `0.1.0-rc.7`
- Public MIT-licensed `v0.1.0` release
- 41 tests plus production and package smoke checks pass
- CI passes on Ubuntu and Windows with Node.js 22.19 and 24
- Installs from a built checkout or release tarball; not currently published to npm