### PR TITLE
Add kentleenot/dsh-trading-toolkit (A-share + US stock trading toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) — Quantitative R&D toolkit: 46 tools across market data, indicators, factor evaluation, walk-forward ML validation, risk, options, bonds, fund simulation.
 - [Realyujie/dsh-us-stocks](https://github.com/Realyujie/dsh-us-stocks) — US stock quotes, price history, financial statements, analyst consensus and news.
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) — PubMed deep-research toolset: literature search, author investigation, same-name disambiguation, institution statistics.
-- [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
+- [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard)
+- [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders. — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
 
 ### Development & Runtime
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) — Quantitative R&D toolkit: 46 tools across market data, indicators, factor evaluation, walk-forward ML validation, risk, options, bonds, fund simulation.
 - [Realyujie/dsh-us-stocks](https://github.com/Realyujie/dsh-us-stocks) — US stock quotes, price history, financial statements, analyst consensus and news.
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) — PubMed deep-research toolset: literature search, author investigation, same-name disambiguation, institution statistics.
-- [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard)
-- [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders. — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
+- [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
+- [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders.
 
 ### Development & Runtime
 


### PR DESCRIPTION
Adds [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) to the Domain & Specialist category: A-share and US stock trading toolkit for DSH agents — realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders. Ships a `dsh.bundle` manifest; `npm test` green.