### PR TITLE
Add dsh-im to Notifications & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [BiBoyang/dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) — Two-way WeChat bridge with in-chat approve/reject and message injection.
 - [Bing-Bryan/dsh-unread-dot](https://github.com/Bing-Bryan/dsh-unread-dot) — macOS Dock badge and chime built on the Badging API.
 - [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) — Bridges sessions, tool calls, and approvals to the macOS notch panel.
+- [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) — Connects DeepSeek Harness to Feishu, WeChat, DingTalk, WeCom, QQ, Slack, Telegram, Discord, and WhatsApp through one settings page, using QR codes, an app manifest, or bot credentials.
 
 ### Git & Engineering
 


### PR DESCRIPTION
Adds [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) to the Notifications & Integrations category.

dsh-im connects DeepSeek Harness to nine IM platforms—Feishu, WeChat, DingTalk, WeCom, QQ, Slack, Telegram, Discord, and WhatsApp—through one settings page, using QR codes, an app manifest, or bot credentials. The plugin is public, MIT-licensed, and published as @xmanrui/dsh-im.

Validation: `git diff --check` passes.