### PR TITLE
docs: add rainow/dsh-simple-wiki-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [highland0971/dsh-native-memory](https://github.com/highland0971/dsh-native-memory) — Native per-workspace memory with approval-gated writes and deterministic recall — no external server.
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded, layered, approval-gated cross-session memory with a typed seam, SQLite provider, and frozen-snapshot injection.
 - [KLRSL/dsh-biomemory](https://github.com/KLRSL/dsh-biomemory) — Biomimetic memory: plain-Markdown data layer, memory metabolism ("dream"), memory pins, semantic recall, and cross-session retrieval.
-- [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — Super-simplified LLM-wiki memory: one auto-injected index document plus one Markdown file per topic read on demand; pending→promote→archive admission with an append-only log and git auto-backup, plain Markdown shared across harnesses.
+- [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — A super-simplified LLM-wiki memory plugin: one index document (auto-loaded) + one markdown file per topic (read only when needed) — no dumping everything into the context and burning tokens. Simple and lightweight, painless to install/uninstall, and freely editable however you like.
 ### Tools & Capabilities
 
 - [988hj7tczd-oss/dsh-computer-use](https://github.com/988hj7tczd-oss/dsh-computer-use) — Cross-platform Computer Use: virtual-mouse operation, AX-tree zero-vision-cost mode, and safety guards.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [highland0971/dsh-native-memory](https://github.com/highland0971/dsh-native-memory) — Native per-workspace memory with approval-gated writes and deterministic recall — no external server.
 - [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) — Bounded, layered, approval-gated cross-session memory with a typed seam, SQLite provider, and frozen-snapshot injection.
 - [KLRSL/dsh-biomemory](https://github.com/KLRSL/dsh-biomemory) — Biomimetic memory: plain-Markdown data layer, memory metabolism ("dream"), memory pins, semantic recall, and cross-session retrieval.
-
+- [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — Super-simplified LLM-wiki memory: one auto-injected index document plus one Markdown file per topic read on demand; pending→promote→archive admission with an append-only log and git auto-backup, plain Markdown shared across harnesses.
 ### Tools & Capabilities
 
 - [988hj7tczd-oss/dsh-computer-use](https://github.com/988hj7tczd-oss/dsh-computer-use) — Cross-platform Computer Use: virtual-mouse operation, AX-tree zero-vision-cost mode, and safety guards.


### PR DESCRIPTION
## Changes

Adds `dsh-simple-wiki-memory` to the **Memory** section in `README.md`:

- [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) — Super-simplified LLM-wiki memory: one auto-injected index document plus one Markdown file per topic read on demand; pending→promote→archive admission with an append-only log and git auto-backup, plain Markdown shared across harnesses.

## Notes

- Repo has the `dsh-plugin` topic
- `package.json` declares `dsh.bundle` (`dsh.bundle.patch` → cordis.patch.yml); installable via `dsh plugin add github:rainow/dsh-simple-wiki-memory`
- Full flow verified locally in the web profile (pending report / promote / archive / git auto-backup)
