### PR TITLE
docs: add dsh-dictate

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AngelosZou/dsh-multi-folder](https://github.com/AngelosZou/dsh-multi-folder) — Secondary working directories with equal read/write/exec permissions.
 - [anweat/dsh-browser](https://github.com/anweat/dsh-browser) — Self-contained Playwright + OpenCLI browser runtime exposing 9 interactive browser tools.
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — Browser Web Speech API voice input: zero server, zero keys.
+- [franksong2702/dsh-dictate](https://github.com/franksong2702/dsh-dictate) — Browser Web Speech dictation for the Composer: recognition needs no dedicated ASR server, key, or model download; reuses Session text and a configured DSH model for contextual phrase hints and optional transcript polishing.
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — HarmonyOS device bridge: screenshot/install/log/crash/UI automation loop.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) — Adds a WSL workspace from the web GUI without reinstalling dsh inside WSL.
 - [buhuikongpan/dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) — Git Bash shell tool for Windows with timeout, sandbox, output truncation, and background jobs.


### PR DESCRIPTION
## Summary

- add [dsh-dictate](https://github.com/franksong2702/dsh-dictate) to the plugin list
- describe its browser-based recognition and optional context-aware model polishing

## Why

dsh-dictate is a public MIT-licensed DSH Composer plugin with the `dsh-plugin` topic. Its current `v0.4.0-alpha.2` prerelease targets DeepSeek Harness `0.1.0-rc.7` and is available from GitHub and npm. Recognition uses browser Web Speech without a dedicated ASR server, API key, or model download; optional polishing reuses the user's configured DSH model and current Session text.

## Verification

- confirmed the GitHub release and npm package are both `v0.4.0-alpha.2`
- confirmed the published package declares RC7 peer dependencies and its README targets DSH `0.1.0-rc.7`
- checked that the one-line description matches the published README
- `git diff --cached --check` passed before commit

## Out of scope

No plugin source, generated catalog, or unrelated list entry is changed.
