### PR TITLE
Add anneheartrecord/dsh-desk-pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 ### Just for Fun
 
 - [AmeKrance/anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) — Desktop pet showing real-time CPU/RAM/GPU/NVMe temperatures.
+- [anneheartrecord/dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) — macOS desk pet in a real always-on-top window rather than a page widget: six states driven by local DSH, and a bundled skill that turns one photo into a whole skin.
 - [Awu12277/dsh-stock-watch](https://github.com/Awu12277/dsh-stock-watch) — A-share watchlist with intraday and candlestick charts in a collapsible popup.
 - [hellodigua/dsh-emoji](https://github.com/hellodigua/dsh-emoji) — Automatically adds emojis to AI replies.
 - [HuanLinOTO/dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) — Pops up a mini-game menu (wordle, match-3) while the model generates.


### PR DESCRIPTION
Adds [anneheartrecord/dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) under **Just for Fun**, alphabetically after `AmeKrance/anan-thermal-monitor` — that is where the list's other desktop pets already live.

A macOS desk pet for DSH. Unlike a pet drawn inside the DSH page, it is a real AppKit window, so it stays above whatever you are working in, fullscreen Spaces included, and follows the agent through six states: idle, working, waiting on a confirmation, error, just-finished, and dozing.

The list already has a few pets, so what is different here: a shipped skill turns **one photo into a whole skin** — the eighteen poses a skin needs, generated by the user's own image tool on their own credentials, with nothing sent anywhere by the plugin. It also runs on the system `/usr/bin/python3` through `ctypes` with no Electron and no dependencies.

macOS only; that is stated in the README rather than left to be discovered.

Per the contributing note: this links the actual plugin repo, not a fork or mirror, and it is published and installable — `dsh plugin --profile web add deepseek-desk-pet` (npm rejected `dsh-desk-pet` as too similar to an unrelated package, so the package and repo names differ). One line, one section, nothing else touched.