### PR TITLE
Add kanneiren/dsh-network-settings (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) — Compares the harness and every plugin against npm/GitHub releases with one-click updates and rollback.
 - [aokamoaki/dsh-startup-guard](https://github.com/aokamoaki/dsh-startup-guard) — Repairs corrupt session logs and quarantines crash-causing bundles so a broken plugin can't brick startup.
 - [ayahunter/dsh-plugin-clinic](https://github.com/ayahunter/dsh-plugin-clinic) — Read-only health check of the installed plugin set: loader health, dependency integrity, install-script risk.
+- [kanneiren/dsh-network-settings](https://github.com/kanneiren/dsh-network-settings) — Visualize the DSH process network path on Windows or WSL with layered DNS/TCP/TLS/HTTP probes, detect stale proxy configuration, and apply snapshot-guarded repairs.
 - [Linxiushen/dsh-workflow-isolate](https://github.com/Linxiushen/dsh-workflow-isolate) — Runs model-written workflows in a fresh QuickJS/WASM runtime with bounded memory, execution fuel, wall time, and child-agent fan-out.
 
 ### Plugin Markets & Managers


### PR DESCRIPTION
Adds [dsh-network-settings](https://github.com/kanneiren/dsh-network-settings): visualizes the DSH process network path on Windows or WSL with layered DNS/TCP/TLS/HTTP probes, detects stale proxy configuration, and applies snapshot-guarded repairs (preview → confirm → rollback).

Per the Contributing guidelines:
- installs via `dsh plugin add` (`dsh.bundle` manifest declared); prebuilt tarball also attached to the [v0.2.1 release](https://github.com/kanneiren/dsh-network-settings/releases/tag/v0.2.1) for install without npm
- description verified against the source: layered probes, drift detection, and the snapshot repair flow all exist in the repo
- linked to the actual plugin repo (not a fork/mirror); `dsh-plugin` GitHub topic set

Thanks for maintaining the list!