### PR TITLE
Add dsh-univer-office to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [buhuikongpan/dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) — Git Bash shell tool for Windows with timeout, sandbox, output truncation, and background jobs.
 
 - [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) — Research-only trading workbench: typed market-data seam with BYO providers, multi-timeframe indicator snapshots, interactive chart cards with provenance-gated model annotations, and a pre-execute risk-guard that blocks execution-shaped tool calls.
+- [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) — Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases with live preview and worktree review.
 
 ### Vision & Multimodal
 


### PR DESCRIPTION
# Add dream-num/dsh-univer-office to Tools & Capabilities

## Summary

Adds [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) to the **Tools & Capabilities** section.

[dsh-univer-office](https://github.com/dream-num/dsh-univer-office) is the Univer office plugin for DeepSeek Harness. It lets the agent create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases, with live preview and worktree-based review in the conversation.

## What it does

- Creates and edits Sheets, Docs, Slides, Bases, and Boards in `.univer` files.
- Imports `.xlsx`, `.csv`, `.tsv`, `.docx`, and `.pptx` files, and exports edited content back to the matching Office format.
- Verifies changes through structured readback, formula recalculation, and Slide layout checks.
- Uses isolated worktrees for every write; users can preview, merge, or discard changes from the conversation.
- Ships version-matched Skills and `univer_*` tools, plus a bundled Gateway, Viewer, and Unit Content Worker.

## Checklist

- [x] Installable via `dsh plugin --profile web add dsh-univer-office`
- [x] `package.json` declares `dsh.bundle` with `cordis.patch.yml`
- [x] Published on npm (`dsh-univer-office`, Apache-2.0)
- [x] Repository has the `dsh-plugin` GitHub topic enabled
- [x] README describes installation, usage, configuration, and limitations
- [x] Only one line added in the appropriate category
