### PR TITLE
Add @beihaizb/dsh-notebook — native Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — HarmonyOS device bridge: screenshot/install/log/crash/UI automation loop.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) — Adds a WSL workspace from the web GUI without reinstalling dsh inside WSL.
 - [buhuikongpan/dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) — Git Bash shell tool for Windows with timeout, sandbox, output truncation, and background jobs.
+- [beihzb/dsh-notebook](https://github.com/beihzb/dsh-notebook) — Native Jupyter-style notebook: real ipykernel sidecar with VS Code-aligned cell UI, tqdm progress bars, inline figures, clickable tracebacks, and per-cell AI revision.
 
 - [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) — Research-only trading workbench: typed market-data seam with BYO providers, multi-timeframe indicator snapshots, interactive chart cards with provenance-gated model annotations, and a pre-execute risk-guard that blocks execution-shaped tool calls.
 


### PR DESCRIPTION
Adds a native Jupyter-style notebook plugin to **Tools & Capabilities**.

- Repo: https://github.com/beihzb/dsh-notebook
- npm: [@beihaizb/dsh-notebook](https://www.npmjs.com/package/@beihaizb/dsh-notebook)

One-line description: real ipykernel sidecar with VS Code-aligned cell UI, tqdm progress bars, inline figures, clickable tracebacks, and per-cell AI revision.

Installs and runs as described in its README. Happy to adjust the category or wording if a better fit exists.