### PR TITLE
Add SandBase Harness runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [ayahunter/dsh-plugin-clinic](https://github.com/ayahunter/dsh-plugin-clinic) — Read-only health check of the installed plugin set: loader health, dependency integrity, install-script risk.
 - [Linxiushen/dsh-workflow-isolate](https://github.com/Linxiushen/dsh-workflow-isolate) — Runs model-written workflows in a fresh QuickJS/WASM runtime with bounded memory, execution fuel, wall time, and child-agent fan-out.
 
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) — Local-first runtime whose installable `managed-agents` DSH plugin exposes six MCP tools for persistent sessions, streamed turns, artifacts, cancellation, audit/replay, and local/Docker/Kubernetes/self-hosted-worker sandboxes.
+
 ### Plugin Markets & Managers
 
 - [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) — Live GitHub `dsh-plugin` topic search with per-repo manifest verification and anti-squatting checks.


### PR DESCRIPTION
## Summary

Adds one factual entry for SandBase Harness under **Development & Runtime**.

This is a concrete DSH integration rather than a topic-only listing: the repository ships an installable `managed-agents` plugin that starts a six-tool MCP bridge for agents, persistent sessions, streamed turns, artifacts, and cancellation. The connected runtime also provides audit/replay and local, Docker, Kubernetes, and self-hosted-worker sandbox backends.

## Validation

- Canonical public repository linked directly
- Carries `dsh` and `dsh-plugin` GitHub topics
- Apache-2.0 licensed
- One-line content addition only
- `git diff --check` passes

## Disclosure

I am affiliated with SandBase AI. The description is based on the public v0.3.4 source and DSH integration docs. AI assistance was used to draft and verify the entry.