### PR TITLE
Add SandBase Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Ikalus1988/MisakaNet](https://github.com/Ikalus1988/MisakaNet) — Failure-recovery memory with BM25 + semantic RAG retrieval over past engineering sessions.
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 85-skill pack for reverse engineering and authorized pentesting/security research.
 
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) — 88 source-verifiable Agent Skills with a native DSH installer targeting `.dsh/skills`, covering research, social intelligence, marketing, and business workflows including multi-source evidence validation.
+
 ### Workflow & Automation
 
 - [1052326311/dsh-plan-lattice](https://github.com/1052326311/dsh-plan-lattice) — Persistent execution contracts and recursive work graphs for long or underspecified tasks.


### PR DESCRIPTION
## Summary

Adds one factual entry for SandBase Skills under **Skills**.

The repository contains 88 source-verifiable Agent Skills and a native installer that targets DSH project discovery at `.dsh/skills`. The catalog covers research, social intelligence, marketing, and business workflows; the flagship multi-source research workflow includes evidence provenance, derivative-source detection, and confidence scoring.

## Validation

- Canonical public repository linked directly
- Carries `dsh`, `dsh-plugin`, `agent-skills`, and `deepseek-harness` topics
- Apache-2.0 licensed
- One-line content addition only
- `git diff --check` passes

## Disclosure

I am affiliated with SandBase AI. The description is based on the public v0.3.4 source and native DSH installation docs. AI assistance was used to draft and verify the entry.