### PR TITLE
docs: add dsh-workspace-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [Ricketts-Guo/dsh-shortcuts](https://github.com/Ricketts-Guo/dsh-shortcuts) — 34 pre-registered keyboard shortcuts (sessions, views, clipboard, models, silent permission cycling), one-click recording to bind your own.
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) — In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Realtime conversation outline: user questions plus Markdown headings, streaming updates, click-to-jump.
+- [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) — Workspace/chat context menu for the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.
 
 ### Usage & Billing
 


### PR DESCRIPTION
Add [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) to the UI Enhancements section.

It adds a workspace/chat context menu to the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.