### PR TITLE
Add Sandbase DSH Plugin Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 
 ### Plugin Markets & Managers
 
+- [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) — Native Settings marketplace for discovering, filtering, installing, and managing the community catalog, with separate Community and Installed views.
 - [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) — Live GitHub `dsh-plugin` topic search with per-repo manifest verification and anti-squatting checks.
 - [863683348/dsh-insight](https://github.com/863683348/dsh-insight) — Plugin insight center: needs-matching, environment recipes, health scoring, security audit verdict.
 - [863683348/dsh-need-finder](https://github.com/863683348/dsh-need-finder) — Requirement-driven plugin discovery matching natural-language needs to a curated directory.


### PR DESCRIPTION
## Summary

Add [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) to the existing **Plugin Markets & Managers** category.

The entry is intentionally factual and scoped to the current preview: native Settings integration, catalog discovery/filtering, installation management, and separate Community / Installed views.

## Verification

- Public repository under the Sandbase organization
- Real UI preview in the README
- Open-source MIT license
- Catalog covers 2,900+ community repositories
- Preview compatibility boundary is documented; no official endorsement or stable-install claim

DeepSeek Harness plugin showcase: https://github.com/deepseek-ai/deepseek-harness/discussions/3467