### PR TITLE
Add 9 DSH plugin entries (kubectl/terraform/k6/az/skillopt/winget/wsl/codex/ssh-pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [buhuikongpan/dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) — Git Bash shell tool for Windows with timeout, sandbox, output truncation, and background jobs.
 
 - [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) — Research-only trading workbench: typed market-data seam with BYO providers, multi-timeframe indicator snapshots, interactive chart cards with provenance-gated model annotations, and a pre-execute risk-guard that blocks execution-shaped tool calls.
+- [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) — Kubernetes ops for the agent: get resources with structured JSON output, describe, logs, exec, apply/delete (confirmed), and port-forward.
+- [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) — Infrastructure as code: gated plan/apply, state/output inspection and config validation via the terraform CLI.
+- [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) — Load testing with Grafana k6: smoke test first, then run scripts and read p95/p99 from the JSON summary.
+- [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure resource management: query/show resources, deploy Bicep/ARM templates and check the activity log.
 
 ### Vision & Multimodal
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) — Infrastructure as code: gated plan/apply, state/output inspection and config validation via the terraform CLI.
 - [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) — Load testing with Grafana k6: smoke test first, then run scripts and read p95/p99 from the JSON summary.
 - [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) — Azure resource management: query/show resources, deploy Bicep/ARM templates and check the activity log.
+- [WODE25500/dsh-skillopt](https://github.com/WODE25500/dsh-skillopt) — Microsoft SkillOpt-Sleep integration: a nightly sleep cycle that harvests sessions, mines recurring tasks, replays them and consolidates validated skills behind a held-out gate.
+- [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) — Windows Package Manager: search/install/upgrade/uninstall/import-export/pin software through native tools.
+- [WODE25500/dsh-wsl](https://github.com/WODE25500/dsh-wsl) — WSL bridge: run Linux commands, manage distros, convert Windows↔WSL paths and copy files — with automatic UTF-16 output normalization.
+- [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) — OpenAI Codex CLI wrapper: one-shot exec, repo review and session resume with a default read-only sandbox.
+- [WODE25500/dsh-ssh-pro](https://github.com/WODE25500/dsh-ssh-pro) — Enhanced SSH ops: connectivity testing, remote ls, ssh-config import, known_hosts fingerprint checks and multi-host exec.
 
 ### Vision & Multimodal
 


### PR DESCRIPTION
Adds nine DeepSeek Harness plugins to the **Tools & Capabilities** category, all following the standard dsh pattern (Schemastery config + `defineTool` + shell executor + `SKILL.md` + bundle patch layer) and verified with mock-context loading and command-construction tests:

| Plugin | What it does |
|---|---|
| [WODE25500/dsh-kubectl](https://github.com/WODE25500/dsh-kubectl) | Kubernetes ops: `kubectl_get` with structured JSON output, describe/logs/exec, apply/delete (user-confirmed), port-forward |
| [WODE25500/dsh-terraform](https://github.com/WODE25500/dsh-terraform) | Infrastructure as code: gated plan/apply, state/output inspection, config validation |
| [WODE25500/dsh-k6](https://github.com/WODE25500/dsh-k6) | Load testing with Grafana k6: smoke-test-first workflow, JSON summary with percentiles |
| [WODE25500/dsh-az](https://github.com/WODE25500/dsh-az) | Azure resource management: query/show, Bicep/ARM deployment, activity log |
| [WODE25500/dsh-skillopt](https://github.com/WODE25500/dsh-skillopt) | Microsoft SkillOpt-Sleep integration: nightly sleep cycle harvesting sessions, mining recurring tasks and consolidating validated skills behind a held-out gate |
| [WODE25500/dsh-winget](https://github.com/WODE25500/dsh-winget) | Windows Package Manager: search/install/upgrade/uninstall/import-export/pin |
| [WODE25500/dsh-wsl](https://github.com/WODE25500/dsh-wsl) | WSL bridge: run Linux commands, distro management, path conversion, cross-boundary copy (UTF-16 output normalized) |
| [WODE25500/dsh-codex](https://github.com/WODE25500/dsh-codex) | OpenAI Codex CLI wrapper: one-shot exec, repo review, session resume (read-only sandbox default) |
| [WODE25500/dsh-ssh-pro](https://github.com/WODE25500/dsh-ssh-pro) | Enhanced SSH ops: connectivity test, remote ls, ssh-config import, fingerprint check, multi-host exec |

MIT / Apache-2.0 where noted.