### PR TITLE
Add scriptsnet/dsh-fleet to Tools & Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AngelosZou/dsh-multi-folder](https://github.com/AngelosZou/dsh-multi-folder) — Secondary working directories with equal read/write/exec permissions.
 - [anweat/dsh-browser](https://github.com/anweat/dsh-browser) — Self-contained Playwright + OpenCLI browser runtime exposing 9 interactive browser tools.
 - [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) — Browser Web Speech API voice input: zero server, zero keys.
+- [scriptsnet/dsh-fleet](https://github.com/scriptsnet/dsh-fleet) — Distributed compute fleet for DSH: pool idle machines (friends' PCs, LAN servers, cloud ECS) into a team and dispatch agent tasks to any online member with results flowing back.
 - [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — HarmonyOS device bridge: screenshot/install/log/crash/UI automation loop.
 - [6Mikao9/dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) — Adds a WSL workspace from the web GUI without reinstalling dsh inside WSL.
 - [buhuikongpan/dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) — Git Bash shell tool for Windows with timeout, sandbox, output truncation, and background jobs.


### PR DESCRIPTION
Add [dsh-fleet](https://github.com/scriptsnet/dsh-fleet) to the **Tools & Capabilities** section.

**dsh-fleet** is a distributed compute fleet plugin for DeepSeek Harness: it pools idle machines (friends' PCs, LAN servers, cloud ECS instances) into teams and lets any machine dispatch agent tasks to any online member, with the worker auto-creating a workspace/session and streaming results back.

- 12 model tools (fleet_card / fleet_teams / fleet_add / fleet_dispatch, etc.)
- Task dispatch with HMAC taskToken auth
- Worker sessions preserved in workspace, GUI-visible
- Zero runtime dependencies, npm-published ([dsh-fleet](https://www.npmjs.com/package/dsh-fleet))