### PR TITLE
docs: add ywleeo/dsh-md-preview to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [lucky8197/dsh-devquest](https://github.com/lucky8197/dsh-devquest) — Turns coding into an RPG: XP, 27+ achievement badges, levels, and seasons.
 - [minybear/DeepSeek-Harness-Pet](https://github.com/minybear/DeepSeek-Harness-Pet) — Codex-style desktop pet mirroring the agent's running state.
 - [Nagi-ovo/dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — Parody ads in 2005-Chinese-web style. All fictional.
+- [ywleeo/dsh-md-preview](https://github.com/ywleeo/dsh-md-preview) — Sidebar workspace-row trigger opens a Markdown preview panel: nested collapsible directory tree, inline rendering, theme-aware, open in the system default app.
 
 ## Writing Your Own Plugin
 


### PR DESCRIPTION
Add [dsh-md-preview](https://github.com/ywleeo/dsh-md-preview) to the UI Enhancements category.

**dsh-md-preview** — Markdown 预览插件：侧边栏 workspace 行触发，嵌套目录树，内联渲染，明暗主题自适应。

- Sidebar workspace-row trigger opens the Markdown preview panel for that workspace
- Nested collapsible directory tree with file counts
- Header actions: open in system default app / refresh / close; file path shown in header
- Mini Markdown renderer (headings/lists/tables/code/blockquote/images/links), theme-aware via DSH design tokens
- Host routes gated by a persisted token with a workspace-path fence