### PR TITLE
Add dsh-plugin-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) — Cost governance: aggregated token/cost metering per model, session and day, session/daily/monthly caps with threshold alerts, alert/block/degrade over-limit policies, carbon estimation, and the /budget command.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Realtime conversation outline: user questions plus Markdown headings, streaming updates, click-to-jump.
 - [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) — Workspace/chat context menu for the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH plugin manager & marketplace: one-click enable/disable, multi-source market (GitHub/Gitee/custom), static index (500+ plugins / 300 skills), skill install/disable, suite (submodule aggregate) one-click assembly, framework upgrade adapter
 
 ### Usage & Billing
 


### PR DESCRIPTION
## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板与市场：

- 一键启用/停用已安装插件（HMR 生效），基础设施保护
- 多源插件市场：GitHub / Gitee 直装 / 自定义搜索源、多源汇总、★ 官方筛选
- 静态索引市场：jsDelivr CDN 分发 500+ 插件 / 300 技能，零 GitHub API 调用
- 技能市场：搜索（agent-skills/claude-skills/dsh-skill）、一键安装/停用/删除、系统保护
- 套装（submodule 聚合仓库）一键装配：bundle 插件 / 技能 / agent 预设 / 普通插件
- 自动收录 CI（每 6 小时刷新索引）、框架升级适配（配置备份 + 补丁重打）
- 已打 dsh-plugin topic

感谢收录！