### PR TITLE
Add dsh-credential-manager and dsh-auto-review (Security & Governance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — MCP management console for the official DSH MCP client: /mcp health diagnostics, a Settings MCP tab with approval-gated server CRUD, and a tool trial console.
 - [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) — OpenTelemetry and Langfuse observability exporter: turn/step/tool/LLM spans, token and cost metrics, sanitized capture, batching, and bounded offline buffering.
 - [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) — Configurable per-turn budgets limiting distinct files, mutation calls, and payload bytes before file-mutation tools run.
+- [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) — Named credential manager: the model uses API keys, tokens, and logins by reference; secrets are injected into each shell run as `DSH_CM_*` env vars and never enter the conversation.
+- [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) — LLM auto-review for sandbox-escalation approvals under the `'auto'` policy: deterministic filter plus a clean-context reviewer model, fail-closed on every error path; requires a patched harness core (patches in core-patches/).
 
 ### Remote Access & Mobile
 


### PR DESCRIPTION
Adds two security plugins under **Security & Governance**:

- **[dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager)** — named user credentials used by reference: the model creates placeholder records, the user enters values in Settings -> Credentials, and secrets reach shell runs only as `DSH_CM_*` env vars. Install-verified on the vanilla upstream harness (`@deepseek-ai/dsh@0.1.0-rc.7`).
- **[dsh-auto-review](https://github.com/accpowered/dsh-auto-review)** — LLM auto-review approval answerer for the `'auto'` approval policy: deterministic filter + clean-context reviewer model, fail-closed. Requires a patched harness core; the patches are included under `core-patches/`.

Both repos carry the `dsh-plugin` topic, ship real working code with unit tests (vitest), and were install-tested before submitting.