### PR TITLE
Add dsh-deepread

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) — Unified static-image generation router: one image_generate tool over config-driven OpenAI-compatible engines (OpenAI Images, Zhipu CogView) with health-aware fallback, durable attachments, and per-session quotas.
 - [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) — The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API reference, and community gotchas.
 - [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) — Security-audit skill pack plus the plugin_vet supply-chain gate: eight bilingual agent skills and an automated pre-install scanner.
+- [xiehuan123/dsh-deepread](https://github.com/xiehuan123/dsh-deepread) — Evidence-first deep reading for books, articles, PDFs, and document sets with claim-evidence reports, knowledge maps, recall questions, a Host tool, and an optional Web reading panel.
 
 ### Vision & Multimodal
 


### PR DESCRIPTION
Adds dsh-deepread to Tools & Capabilities.

The repository ships a public DeepSeek Harness bundle, the deepread Host tool, a packaged skill, and an optional Web reading panel. Version 1.0.0 is published on npm and tagged on GitHub.

Repository: https://github.com/xiehuan123/dsh-deepread
Release: https://github.com/xiehuan123/dsh-deepread/releases/tag/v1.0.0
