### PR TITLE
Add dsh-web-app-launcher to Development & Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [beihzb/dsh-notebook](https://github.com/beihzb/dsh-notebook) — Native Jupyter-style notebook: real ipykernel sidecar, VS Code-aligned cell UI, tqdm progress, inline figures, per-cell AI revision.
 
 - [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) — Local-first runtime whose installable `managed-agents` DSH plugin exposes six MCP tools for persistent sessions, streamed turns, artifacts, cancellation, audit/replay, and local/Docker/Kubernetes/self-hosted-worker sandboxes.
+- [sylkmpo/dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher) — Runs dsh web like a Windows desktop app while the native web UI stays the engine (no Electron, no fork): auto-creates a DeepSeek Harness.lnk shortcut that opens the Web UI in a frameless Edge/Chrome/Brave/Vivaldi app window and exits the harness when the window closes.
 
 ### Plugin Markets & Managers
 


### PR DESCRIPTION
Add an entry for [dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher) under **Development & Runtime**:

- Runs `dsh web` like a Windows desktop app while the native web UI stays the engine (no Electron, no fork, no repackaging)
- First run auto-creates a `DeepSeek Harness.lnk` desktop shortcut; double-clicking opens the Web UI in a frameless Edge/Chrome/Brave/Vivaldi `--app` window (no tab bar, no address bar), and closing the window exits the harness
- Install: `dsh plugin --profile web add github:sylkmpo/dsh-web-app-launcher` (Windows 10/11)
- MIT; effect screenshots in the repo README