### PR TITLE
Add dsh-about (Settings About tab: update check + one-click update) to UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) — Cost governance: aggregated token/cost metering per model, session and day, session/daily/monthly caps with threshold alerts, alert/block/degrade over-limit policies, carbon estimation, and the /budget command.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Realtime conversation outline: user questions plus Markdown headings, streaming updates, click-to-jump.
 - [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) — Workspace/chat context menu for the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.
+- [YannZhou/dsh-about](https://github.com/YannZhou/dsh-about) — Settings "About" tab: DeepSeek logo, version info, npm latest/next update check with one-click global update + auto-restart, and GitHub releases history.
 
 ### Usage & Billing
 


### PR DESCRIPTION
New community plugin: [YannZhou/dsh-about](https://github.com/YannZhou/dsh-about) — Settings center **About** tab for DeepSeek Harness web profile:

- DeepSeek logo + version / platform / repo info
- **Check for updates** (npm `latest`/`next`, takes the newer) with a version picker
- One-click **`npm install -g` update with auto-restart** of `dsh web`
- GitHub releases history (latest 10, rendered in Chinese)

Declares `dsh.bundle` + `dsh.client` manifests: installs with `dsh plugin --profile web add`, zero runtime dependencies (vendored semver), fully reversible. Includes an AI-executable install runbook (AI-INSTALL.md).