### PR TITLE
Add dsh-hawkeye-scan (AI security scanning workbench)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — MCP management console for the official DSH MCP client: /mcp health diagnostics, a Settings MCP tab with approval-gated server CRUD, and a tool trial console.
 - [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) — OpenTelemetry and Langfuse observability exporter: turn/step/tool/LLM spans, token and cost metrics, sanitized capture, batching, and bounded offline buffering.
 - [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) — Configurable per-turn budgets limiting distinct files, mutation calls, and payload bytes before file-mutation tools run.
-- [liuqingman/hawkeye-scan-workbench](https://github.com/liuqingman/hawkeye-scan-workbench) — AI-driven source-code security scanning workbench: 5 model tools (start/finding/status/report/list) plus a /hawkeye web UI and JSON/Markdown/HTML vulnerability reports; zero-dependency Cordis plugin, installable as agent preset or npm package.
+- [liuqingman/dsh-hawkeye-scan](https://github.com/liuqingman/dsh-hawkeye-scan) — AI-driven source-code security scanning workbench: 5 model tools (start/finding/status/report/list) plus a /hawkeye web UI and JSON/Markdown/HTML vulnerability reports; zero-dependency Cordis plugin, installable as agent preset or npm package.
 
 ### Remote Access & Mobile
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — MCP management console for the official DSH MCP client: /mcp health diagnostics, a Settings MCP tab with approval-gated server CRUD, and a tool trial console.
 - [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) — OpenTelemetry and Langfuse observability exporter: turn/step/tool/LLM spans, token and cost metrics, sanitized capture, batching, and bounded offline buffering.
 - [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) — Configurable per-turn budgets limiting distinct files, mutation calls, and payload bytes before file-mutation tools run.
+- [liuqingman/hawkeye-scan-workbench](https://github.com/liuqingman/hawkeye-scan-workbench) — AI-driven source-code security scanning workbench: 5 model tools (start/finding/status/report/list) plus a /hawkeye web UI and JSON/Markdown/HTML vulnerability reports; zero-dependency Cordis plugin, installable as agent preset or npm package.
 
 ### Remote Access & Mobile
 


### PR DESCRIPTION
## What

Add [dsh-hawkeye-scan](https://github.com/liuqingman/dsh-hawkeye-scan) to **Security & Governance**.

AI-driven source-code security scanning workbench for DeepSeek Harness (DSH):
- 5 model tools: `hawkeye_scan_start` / `hawkeye_scan_finding` / `hawkeye_scan_status` / `hawkeye_scan_report` / `hawkeye_scan_list`
- `/hawkeye` web UI (task list, vuln table, full report page) served on the DSH GUI port
- Report outputs: `report.json` / `report.md` / `report.html`; findings stored as Markdown + YAML frontmatter (signature = `sha256(norm_title|cwe|file)[:16]`, compatible with the Anthropic defending-code-reference-harness fingerprint scheme)
- Zero-dependency Cordis plugin (pure JS, built-in SHA-256), installable as an **agent preset** (copy directory to `~/.dsh/.agent-presets/`) or **npm package** (`dsh-hawkeye-scan`)

## Verified

End-to-end on a real session: scanned `/workspace/hawkeye/exploit_poc` (4 real findings: SQL injection, hardcoded credential, path traversal, SSH host-key validation) plus a 55-finding vehicle (xos) scan; all three report formats and the web UI exercised. Preview: `docs/screenshot-workbench.svg` in the repo (GitHub-rendered SVG).

![workbench](https://raw.githubusercontent.com/liuqingman/dsh-hawkeye-scan/main/docs/screenshot-workbench.svg)

## Checklist

- [x] One-line entry, actual plugin repo link (not fork/mirror)
- [x] Plugin installs and does what the description says
