### PR TITLE
Add local-ocr offline OCR skill to Skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 85-skill pack for reverse engineering and authorized pentesting/security research.
 
 - [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) — 88 source-verifiable Agent Skills with a native DSH installer targeting `.dsh/skills`, covering research, social intelligence, marketing, and business workflows including multi-source evidence validation.
+- [Daive1119/local-ocr](https://github.com/Daive1119/local-ocr) — Offline local OCR skill for vision-less models: Windows native engine first (RapidOCR/Tesseract fallback), images + PDF, structured JSON output with confidence semantics, zero cloud cost.
 
 ### Workflow & Automation
 


### PR DESCRIPTION
Adds [Daive1119/local-ocr](https://github.com/Daive1119/local-ocr) to the Skills list: offline local OCR skill for vision-less models (Windows native OCR -> RapidOCR -> Tesseract, images + PDF, structured JSON with confidence semantics, zero cloud cost). MIT, v1.0.0.