### PR TITLE
Add DSH Agent Market (AI-native marketplace) to Plugin Markets & Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [DshMarketPlace/dsh-plugins-store](https://github.com/DshMarketPlace/dsh-plugins-store) — Browse and install DSH plugins from inside the harness through `/store`, a Settings tab, and agent search/install tools, with approval-gated installs.
 - [huguangyu666/dsh-store](https://github.com/huguangyu666/dsh-store) — npm-authoritative catalog plus curated list (550+ plugins), with quality verification.
 - [icefall7/dsh-plugin-scout](https://github.com/icefall7/dsh-plugin-scout) — Scouts every `dsh-plugin`-tagged repo and judges each as worth trying, watching, or skipping.
+- [chenzhi-clude/dsh-plugin-market](https://github.com/chenzhi-clude/dsh-plugin-market) — AI-native marketplace with a machine-readable registry (all.json + llms.txt) built for agent-driven plugin search and one-command install.
 
 ### Just for Fun
 


### PR DESCRIPTION
## What

Adds **DSH Agent Market** ([chenzhi-clude/dsh-plugin-market](https://github.com/chenzhi-clude/dsh-plugin-market)) to the **Plugin Markets & Managers** section.

## Why

It is an AI-native DSH plugin marketplace:

- 3600+ plugins auto-collected daily from GitHub by CI, 11 categories, stars/downloads per entry
- Machine-readable registry (`registry/all.json`, ~3MB JSON with id/spec/tags/category/stars/verified fields) plus `llms.txt`, designed so AI coding agents can search, evaluate, and install plugins for their users via `dsh plugin --profile web add <spec>`
- Web catalog: https://chenzhi-clude.github.io/dsh-plugin-market/
- Submission = PR a JSON file into `registry/curated/`, live within seconds