### PR TITLE
Add dsh-agent-sticky-note — agent-to-human notice board (Notifications & Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AbcdefgXW/dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) — IM channel bridge (WeChat/QQ/Feishu) with proactive push to your phone.
 - [AI-Galaxy-GPU/dsh-sound](https://github.com/AI-Galaxy-GPU/dsh-sound) — Per-event sound notifications for completion, approval, question, and task-failure.
 - [Alan2Z/dsh-speak](https://github.com/Alan2Z/dsh-speak) — Voice-announces the final reply via native OS voices on Windows and macOS.
+- [alanpaul1969/dsh-agent-sticky-note](https://github.com/alanpaul1969/dsh-agent-sticky-note) — Agent-to-human notice board: renders pending decisions, notices, and version updates your agent (or background cron/headless workers) writes to a note file, as a Settings tab — survives chat floods and remote (Tailscale) sessions.
 - [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) — High-reliability Feishu/Lark bridge with QR auth and card-based approval commands.
 - [aokamoaki/dsh-notify](https://github.com/aokamoaki/dsh-notify) — Windows toast + sound on turn done/error/goal, plus ask & approval alerts.
 - [BiBoyang/dsh-im-bridge](https://github.com/BiBoyang/dsh-im-bridge) — Two-way WeChat bridge with in-chat approve/reject and message injection.


### PR DESCRIPTION
## What

Adds [alanpaul1969/dsh-agent-sticky-note](https://github.com/alanpaul1969/dsh-agent-sticky-note) under **Notifications & Integrations** (one line, alphabetical, per contributing rules).

## Why it fits the category

Unlike the existing sticky-note plugins (human note-taking), this one is an **agent→human notification surface**: it renders pending decisions, notices, and version updates written by the agent / background watchers / headless workers to a note file, as a Settings tab — so agent-raised decision items survive chat-message floods and stay visible over remote sessions (e.g. Tailscale, where the machine Desktop is unreachable).

## Install check (as required by Contributing)

- Verified installed and working on DSH `0.1.1-rc.2` (Settings → 📌 tab, `/api/sticky-note` endpoint).
- Also published on npm: [`dsh-agent-sticky-note@0.1.2`](https://www.npmjs.com/package/dsh-agent-sticky-note) — `dsh plugin --profile web add dsh-agent-sticky-note`.
- Zero runtime deps; read-only display; MIT.