### PR TITLE
add dsh-milestone under UI Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) — Cost governance: aggregated token/cost metering per model, session and day, session/daily/monthly caps with threshold alerts, alert/block/degrade over-limit policies, carbon estimation, and the /budget command.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Realtime conversation outline: user questions plus Markdown headings, streaming updates, click-to-jump.
 - [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) — Workspace/chat context menu for the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.
+- [SnowCrescenter-tech/dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) — Git-style dot timeline on the right edge of the DSH web UI: one dot per user message, hover for content & metadata, click to jump; full-session list, in-session & cross-session search, #msg= deep-link bookmarks, keyboard nav.
 
 ### Usage & Billing
 


### PR DESCRIPTION
Adds [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) to the UI Enhancements category — a Git-style dot timeline on the right edge of the DSH web UI (one dot per user message, hover for content & metadata, click to jump), with a full-session list, in-session & cross-session search, #msg= deep-link bookmarks, and keyboard navigation. Installs via \dsh plugin --profile web add dsh-milestone\; npm package dsh-milestone@0.6.6.