### PR TITLE
Add Blue — full interactive TUI for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [AcidGr/dsh-web-lan-access](https://github.com/AcidGr/dsh-web-lan-access) — Fixes the Web UI so it survives LAN or Tailscale direct-IP access.
 - [AKS1st/dsh-mermaid](https://github.com/AKS1st/dsh-mermaid) — Renders Mermaid fences as sanitized, theme-aware SVG diagrams.
 - [AKS1st/dsh-sysmon](https://github.com/AKS1st/dsh-sysmon) — Floating CPU/memory/disk widget with threshold color warnings.
+- [dsh-blue/blue](https://github.com/dsh-blue/blue) — Full interactive TUI for DeepSeek Harness: streaming Markdown transcript, tool-call cards, approval overlays, session management, and theming — every render component a hot-swappable plugin.
 - [hanzhangzzz/dsh-diagram](https://github.com/hanzhangzzz/dsh-diagram) — Editable Excalidraw diagrams embedded directly in conversations.
 - [giiiiiithub/terminal](https://github.com/giiiiiithub/terminal) — A real PTY terminal panel via node-pty and xterm.js, with multi-tab sessions and a dock/floating window.
 - [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) — Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings flagged as you type. Uses the model dsh is already configured with, so no API key.


### PR DESCRIPTION
Adds [Blue](https://github.com/dsh-blue/blue) to **UI Enhancements** (alphabetical, between AKS1st/dsh-sysmon and hanzhangzzz/dsh-diagram).

- Interactive TUI for DeepSeek Harness: a `pi-tui` renderer mounted as an out-of-tree Cordis plugin bundle — streaming Markdown transcript, tool-call cards, approval overlays, session management, theming, external editor integration.
- Installs from npm: `npm i -g @dsh-blue/blue-cli@rc` (`blue`), or `dsh plugin --profile blue add @dsh-blue/blue@rc` over an existing dsh host. Verified installable on the current preview line (`0.1.0-rc.5`).
- MIT, five workspace packages under the `@dsh-blue` scope, actively maintained; docs at https://dsh-blue.dev/en/

One line, links the actual repo, description matches what the plugin does — per the contributing notes. Happy to adjust wording if you'd like it shorter.