### PR TITLE
Add dsh-fixed-income-skills to Domain & Specialist

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [wade20250715/dsh-pubmed](https://github.com/wade20250715/dsh-pubmed) — PubMed deep-research toolset: literature search, author investigation, same-name disambiguation, institution statistics.
 - [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) — Academic writing guard: removes AI-style defensive writing, protects scientific evidence, calibrates tone toward a target journal.
 - [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) — A-share and US stock trading toolkit for DSH agents: realtime quotes, OHLCV klines, ADX three-state regime signals and simple backtest previews via EastMoney. Read-only, never places orders.
+- [liyc-sys/dsh-fixed-income-skills](https://github.com/liyc-sys/dsh-fixed-income-skills) — Fixed-income / credit skills: issuer rating-migration watch (fundamentals + market-implied spread + catalysts) and rate-scenario analysis (historically anchored curve scenarios with duration-based exposure impact). Ported from the LLMQuant financial Agent Skills library.
 
 ### Development & Runtime
 


### PR DESCRIPTION
Adds [liyc-sys/dsh-fixed-income-skills](https://github.com/liyc-sys/dsh-fixed-income-skills): fixed-income / credit analysis skills for DSH — issuer rating-migration watch and rate-scenario analysis, ported from the LLMQuant financial Agent Skills library.

The ecosystem currently has equity/technical-analysis plugins (dsh-trading-toolkit, dsh-us-stocks, dsh-quant) but nothing on the fixed-income / credit side; this fills that gap. Installs by copying the two skill bundles into `~/.dsh/skills`; format follows the dsh skill spec (kebab-case name, frontmatter description, bundle layout).