### PR TITLE
Add dsh-swarm-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) — Cost governance: aggregated token/cost metering per model, session and day, session/daily/monthly caps with threshold alerts, alert/block/degrade over-limit policies, carbon estimation, and the /budget command.
 - [urzeye/dsh-outline](https://github.com/urzeye/dsh-outline) — Realtime conversation outline: user questions plus Markdown headings, streaming updates, click-to-jump.
 - [dsh-workspace-menu](https://github.com/0imzero/dsh-workspace-menu) — Workspace/chat context menu for the DSH home page: pin, rename, open in file explorer, archive, fork, copy, and open in a new window.
+- [stephenlzc/dsh-swarm-panel#dsh-swarm-plugin](https://github.com/stephenlzc/dsh-swarm-panel/tree/main/dsh-swarm-plugin) — Conversation Flow observability for DeepSeek Harness swarms, with topology, routed-message inspection, HITL pauses, Live follow, and child-session navigation.
 
 ### Usage & Billing
 


### PR DESCRIPTION
## Summary

- Add `stephenlzc/dsh-swarm-panel#dsh-swarm-plugin` to UI Enhancements.
- Link directly to the installable `dsh-swarm-plugin` monorepo subpackage.

The plugin provides Conversation Flow observability for DeepSeek Harness swarms, including topology, routed-message inspection, HITL pauses, Live follow, and child-session navigation.

## Verification

- `git diff --check` passed.
- The entry uses a factual one-line description and the canonical public repository URL.
