### PR TITLE
add chunfenxiazhi-collab/dsh-stability-audit (Development & Runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Tag your own plugin repo with the [`dsh-plugin`](https://github.com/topics/dsh-p
 - [beihzb/dsh-notebook](https://github.com/beihzb/dsh-notebook) — Native Jupyter-style notebook: real ipykernel sidecar, VS Code-aligned cell UI, tqdm progress, inline figures, per-cell AI revision.
 
 - [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) — Local-first runtime whose installable `managed-agents` DSH plugin exposes six MCP tools for persistent sessions, streamed turns, artifacts, cancellation, audit/replay, and local/Docker/Kubernetes/self-hosted-worker sandboxes.
+- [chunfenxiazhi-collab/dsh-stability-audit](https://github.com/chunfenxiazhi-collab/dsh-stability-audit) — Stability audit for installed dsh plugins: static risk grading (hook surface, startup work, inject, entry, dep ranges) plus optional isolated install verification.
 
 ### Plugin Markets & Managers
 


### PR DESCRIPTION
Add chunfenxiazhi-collab/dsh-stability-audit: stability audit for installed dsh plugins with isolated install verification. Repo has the dsh-plugin topic.